### PR TITLE
feat(youtube-metadata): add YouTube metadata handling and refresh functionality

### DIFF
--- a/backend/app/api_schema/videos.py
+++ b/backend/app/api_schema/videos.py
@@ -20,6 +20,10 @@ class VideoResponse(BaseModel):
     transcription: Optional[str] = None
     status: VideoProcessingStatus
     error_message: Optional[str] = None
+    youtube_thumbnail_url: Optional[str] = None
+    youtube_duration: Optional[str] = None
+    youtube_channel_title: Optional[str] = None
+    youtube_metadata_updated_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
     listings_count: int = 0

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -157,6 +157,8 @@ POT_DISABLE_INNERTUBE = os.getenv("POT_DISABLE_INNERTUBE", "false").lower() == "
 YTDLP_PLAYER_CLIENT = os.getenv("YTDLP_PLAYER_CLIENT", "default,mweb")
 
 TOR_PROXY = "socks5://tor:9150"
+# Option to disable Tor for video downloads (Tor may be blocked by Google/YouTube for downloads)
+YTDLP_DISABLE_TOR_FOR_DOWNLOADS = os.getenv("YTDLP_DISABLE_TOR_FOR_DOWNLOADS", "false").lower() == "true"
 
 # Base URL for Places API
 PLACES_BASE_URL = "https://places.googleapis.com/v1"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,8 @@ from fastapi.exception_handlers import request_validation_exception_handler
 
 from app.utils.logging import setup_logger
 from app.utils.youtube_cookies import refresh_youtube_cookies
+from app.services.video_metadata_refresh import refresh_stale_video_metadata
+from app.database import AsyncSessionLocal
 from app.routes.tags import router as tags_router
 from app.routes.cuisines import router as cuisines_router
 from app.routes.videos import router as videos_router
@@ -32,13 +34,34 @@ from app.routes.admin.cuisines import admin_cuisines_router
 from app.routes.admin.dashboard import router as dashboard_router
 from app.routes.geocoding import router as geocoding_router
 from app.routes.cache import router as cache_router
+from app.routes.youtube_metadata import router as youtube_metadata_router
 
 # Configure logging
 logger = setup_logger(__name__)
 
 # Create scheduler before app
 scheduler = AsyncIOScheduler()
-scheduler.add_job(refresh_youtube_cookies, 'interval', hours=23)  # Refresh ~daily
+
+# Refresh YouTube cookies daily
+scheduler.add_job(refresh_youtube_cookies, 'interval', hours=23)
+
+# Refresh YouTube video metadata weekly (Sunday 2 AM)
+async def refresh_video_metadata_job():
+    """Weekly job to refresh YouTube video metadata."""
+    async with AsyncSessionLocal() as db:
+        try:
+            result = await refresh_stale_video_metadata(db, days_threshold=7)
+            logger.info(f"Weekly metadata refresh completed: {result}")
+        except Exception as e:
+            logger.error(f"Error in weekly metadata refresh job: {e}")
+
+scheduler.add_job(
+    refresh_video_metadata_job,
+    'cron',
+    day_of_week='sun',
+    hour=2,
+    minute=0
+)  # Weekly on Sunday at 2 AM
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -87,6 +110,7 @@ app.include_router(admin_cuisines_router, prefix="/admin/cuisines", tags=["admin
 app.include_router(geocoding_router, prefix="/geocoding", tags=["geocoding"])
 app.include_router(dashboard_router, prefix="/admin/dashboard", tags=["admin"])
 app.include_router(cache_router, prefix="/cache", tags=["cache"])
+app.include_router(youtube_metadata_router, prefix="/youtube-metadata", tags=["youtube-metadata"])
 
 
 # Custom exception handler for validation errors

--- a/backend/app/models/video.py
+++ b/backend/app/models/video.py
@@ -30,6 +30,10 @@ class Video(Base):
     transcription = Column(Text) # From Whisper
     status = Column(SQLEnum(VideoProcessingStatus), default=VideoProcessingStatus.PENDING, server_default=VideoProcessingStatus.PENDING.value, nullable=False) # Processing status
     error_message = Column(Text, nullable=True) # Error message if processing failed
+    youtube_thumbnail_url = Column(String(500), nullable=True) # Best quality thumbnail from YouTube
+    youtube_duration = Column(String(50), nullable=True) # ISO 8601 duration (e.g., "PT5M30S")
+    youtube_channel_title = Column(String(255), nullable=True) # Channel name
+    youtube_metadata_updated_at = Column(DateTime(timezone=True), nullable=True) # Last metadata refresh timestamp
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/backend/app/routes/youtube_metadata.py
+++ b/backend/app/routes/youtube_metadata.py
@@ -1,0 +1,205 @@
+"""
+API endpoints for fetching and refreshing YouTube video metadata.
+"""
+import json
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from redis import Redis
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, update
+
+from app.config import REDIS_URL, YOUTUBE_API_KEY
+from app.database import get_async_db
+from app.models.video import Video
+from app.services.youtube_metadata import fetch_video_metadata
+from app.utils.logging import setup_logger
+
+router = APIRouter()
+logger = setup_logger(__name__)
+
+redis_client = Redis.from_url(REDIS_URL) if REDIS_URL else None
+
+
+@router.get("/{video_id}")
+async def get_youtube_metadata(
+    video_id: str,
+    db: AsyncSession = Depends(get_async_db)
+):
+    """
+    Get YouTube metadata for a video ID.
+    
+    Returns cached metadata from database or Redis if available,
+    otherwise fetches fresh from YouTube API.
+    
+    - **video_id**: YouTube video ID
+    """
+    try:
+        if not YOUTUBE_API_KEY:
+            raise HTTPException(
+                status_code=500,
+                detail="YouTube API key not configured"
+            )
+        
+        # Check Redis cache first (1 week TTL)
+        cache_key = f"youtube_metadata:{video_id}"
+        if redis_client:
+            cached_data = redis_client.get(cache_key)
+            if cached_data:
+                logger.info(f"Returning cached metadata for video {video_id} from Redis")
+                return json.loads(cached_data)
+        
+        # Check database for existing video record
+        result = await db.execute(
+            select(Video).where(Video.youtube_video_id == video_id)
+        )
+        video = result.scalar_one_or_none()
+        
+        # If video exists in DB and has recent metadata, return it
+        if video and video.youtube_metadata_updated_at:
+            # Check if metadata is less than 7 days old
+            days_since_update = (datetime.now(video.youtube_metadata_updated_at.tzinfo) - video.youtube_metadata_updated_at).days
+            if days_since_update < 7:
+                metadata = {
+                    "title": video.title,
+                    "description": video.description,
+                    "published_at": video.published_at.isoformat() if video.published_at else None,
+                    "thumbnail_url": video.youtube_thumbnail_url,
+                    "duration": video.youtube_duration,
+                    "channel_title": video.youtube_channel_title,
+                }
+                # Cache in Redis
+                if redis_client:
+                    redis_client.setex(cache_key, 604800, json.dumps(metadata))  # 1 week
+                logger.info(f"Returning cached metadata for video {video_id} from database")
+                return metadata
+        
+        # Fetch fresh metadata from YouTube API
+        logger.info(f"Fetching fresh metadata for video {video_id} from YouTube API")
+        metadata = await fetch_video_metadata(video_id)
+        
+        if not metadata:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Could not fetch metadata for video {video_id}"
+            )
+        
+        # Update database if video exists
+        if video:
+            await db.execute(
+                update(Video)
+                .where(Video.id == video.id)
+                .values(
+                    youtube_thumbnail_url=metadata.get("thumbnail_url"),
+                    youtube_duration=metadata.get("duration_iso"),
+                    youtube_channel_title=metadata.get("channel_title"),
+                    youtube_metadata_updated_at=datetime.now()
+                )
+            )
+            await db.commit()
+        
+        # Prepare response (exclude internal fields)
+        response_metadata = {
+            "title": metadata.get("title"),
+            "description": metadata.get("description"),
+            "published_at": metadata.get("published_at"),
+            "thumbnail_url": metadata.get("thumbnail_url"),
+            "duration": metadata.get("duration"),
+            "channel_title": metadata.get("channel_title"),
+        }
+        
+        # Cache in Redis (1 week)
+        if redis_client:
+            redis_client.setex(cache_key, 604800, json.dumps(response_metadata))
+        
+        return response_metadata
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching YouTube metadata for video {video_id}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error while fetching YouTube metadata: {str(e)}"
+        )
+
+
+@router.post("/{video_id}/refresh")
+async def refresh_youtube_metadata(
+    video_id: str,
+    db: AsyncSession = Depends(get_async_db)
+):
+    """
+    Force refresh YouTube metadata for a video ID.
+    
+    Fetches fresh metadata from YouTube API and updates database/cache.
+    
+    - **video_id**: YouTube video ID
+    """
+    try:
+        if not YOUTUBE_API_KEY:
+            raise HTTPException(
+                status_code=500,
+                detail="YouTube API key not configured"
+            )
+        
+        # Fetch fresh metadata from YouTube API
+        logger.info(f"Force refreshing metadata for video {video_id}")
+        metadata = await fetch_video_metadata(video_id)
+        
+        if not metadata:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Could not fetch metadata for video {video_id}"
+            )
+        
+        # Find video in database
+        result = await db.execute(
+            select(Video).where(Video.youtube_video_id == video_id)
+        )
+        video = result.scalar_one_or_none()
+        
+        if video:
+            # Update database
+            await db.execute(
+                update(Video)
+                .where(Video.id == video.id)
+                .values(
+                    youtube_thumbnail_url=metadata.get("thumbnail_url"),
+                    youtube_duration=metadata.get("duration_iso"),
+                    youtube_channel_title=metadata.get("channel_title"),
+                    youtube_metadata_updated_at=datetime.now()
+                )
+            )
+            await db.commit()
+            logger.info(f"Updated metadata for video {video_id} in database")
+        
+        # Update Redis cache
+        cache_key = f"youtube_metadata:{video_id}"
+        response_metadata = {
+            "title": metadata.get("title"),
+            "description": metadata.get("description"),
+            "published_at": metadata.get("published_at"),
+            "thumbnail_url": metadata.get("thumbnail_url"),
+            "duration": metadata.get("duration"),
+            "channel_title": metadata.get("channel_title"),
+        }
+        
+        if redis_client:
+            redis_client.setex(cache_key, 604800, json.dumps(response_metadata))  # 1 week
+            logger.info(f"Updated cache for video {video_id}")
+        
+        return response_metadata
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error refreshing YouTube metadata for video {video_id}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error while refreshing YouTube metadata: {str(e)}"
+        )
+
+

--- a/backend/app/scripts/refresh_youtube_metadata.py
+++ b/backend/app/scripts/refresh_youtube_metadata.py
@@ -1,0 +1,55 @@
+"""
+Script to refresh YouTube video metadata for all videos.
+Can be run as a standalone script or scheduled via cron.
+
+Usage:
+    python -m app.scripts.refresh_youtube_metadata
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path to allow imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.database import AsyncSessionLocal
+from app.services.video_metadata_refresh import refresh_stale_video_metadata
+from app.utils.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+
+async def main():
+    """Main function to run the metadata refresh."""
+    logger.info("Starting YouTube metadata refresh job")
+    
+    async with AsyncSessionLocal() as db:
+        try:
+            result = await refresh_stale_video_metadata(
+                db=db,
+                days_threshold=7,
+                batch_size=50,
+                rate_limit_delay=0.1
+            )
+            
+            logger.info(f"Refresh job completed: {result}")
+            
+            if result.get("error"):
+                logger.error(f"Job failed with error: {result['error']}")
+                sys.exit(1)
+            else:
+                logger.info(
+                    f"Successfully refreshed {result['successful']} videos, "
+                    f"{result['failed']} failed out of {result['total']} total"
+                )
+                sys.exit(0)
+                
+        except Exception as e:
+            logger.error(f"Fatal error in metadata refresh job: {e}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+

--- a/backend/app/services/transcription_nlp.py
+++ b/backend/app/services/transcription_nlp.py
@@ -42,6 +42,7 @@ from app.config import (
     POT_DISABLE_INNERTUBE,
     YTDLP_PLAYER_CLIENT,
     YTDLP_PROXY,
+    YTDLP_DISABLE_TOR_FOR_DOWNLOADS,
 )
 from app.database import AsyncSessionLocal
 from app.services.jobs import JobService
@@ -385,16 +386,13 @@ async def download_audio(video_url: str, video: Video) -> Optional[str]:
                     "No valid YouTube cookie file found after refresh attempt.",
                     details,
                 )
-            # elif YTDLP_COOKIES_FROM_BROWSER:
-            #     # Handle browser profile properly - if None or empty, use just the browser name
-            #     if YTDLP_BROWSER_PROFILE and YTDLP_BROWSER_PROFILE.strip():
-            #         ydl_opts["cookiesfrombrowser"] = (YTDLP_COOKIES_FROM_BROWSER, YTDLP_BROWSER_PROFILE)
-            #         logger.info(f"Using cookies from browser: {YTDLP_COOKIES_FROM_BROWSER} with profile: {YTDLP_BROWSER_PROFILE}")
-            #     else:
-            #         ydl_opts["cookiesfrombrowser"] = (YTDLP_COOKIES_FROM_BROWSER,)
-            #         logger.info(f"Using cookies from browser: {YTDLP_COOKIES_FROM_BROWSER} (default profile)")
             
             # Add proxy configuration
+            # Check if Tor should be disabled for downloads (Google/YouTube often blocks Tor for video downloads)
+            if YTDLP_DISABLE_TOR_FOR_DOWNLOADS:
+                logger.info("YTDLP_DISABLE_TOR_FOR_DOWNLOADS is enabled - skipping Tor for video downloads")
+                use_tor = False
+            
             if use_tor and TOR_PROXY:
                 # Check if Tor is healthy before using it
                 tor_healthy = await _check_tor_health()
@@ -559,8 +557,28 @@ async def download_audio(video_url: str, video: Video) -> Optional[str]:
             err = str(e)
             logger.error(f"Download error for {video_url}: {err}")
 
-            # Detect geo-restriction; fallback to Tor on next attempt
             err_l = err.lower()
+            
+            # PRIORITY FIX: Detect 403 Forbidden when using Tor - retry without Tor
+            # Google/YouTube often block video downloads from Tor IPs even with valid cookies
+            is_403_forbidden = (
+                "http error 403" in err_l
+                or "403" in err_l
+                or "forbidden" in err_l
+            )
+            if is_403_forbidden and use_tor and attempt < max_attempts - 1:
+                logger.warning("=== TOR PROXY BLOCKING DETECTED === 403 Forbidden error with Tor enabled")
+                logger.warning("Google/YouTube is blocking video downloads from Tor IP. Retrying without Tor proxy...")
+                use_tor = False
+                # Cleanup and retry without Tor
+                if downloaded_file and os.path.exists(downloaded_file):
+                    os.remove(downloaded_file)
+                if os.path.exists(final_output_path):
+                    os.remove(final_output_path)
+                await asyncio.sleep(2)
+                continue
+
+            # Detect geo-restriction; fallback to Tor on next attempt
             geo_hit = (
                 "not made this video available in your country" in err_l
                 or "available in your country" in err_l

--- a/backend/app/services/video_metadata_refresh.py
+++ b/backend/app/services/video_metadata_refresh.py
@@ -1,0 +1,157 @@
+"""
+Background service for refreshing YouTube video metadata.
+Refreshes metadata for videos that haven't been updated in 7+ days.
+"""
+import asyncio
+from datetime import datetime, timedelta
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, update, and_
+
+from app.models.video import Video
+from app.services.youtube_metadata import fetch_video_metadata
+from app.utils.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+
+async def refresh_video_metadata(
+    db: AsyncSession,
+    video_id: str,
+    video: Video
+) -> bool:
+    """
+    Refresh metadata for a single video.
+    
+    Args:
+        db: Database session
+        video_id: YouTube video ID
+        video: Video model instance
+        
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        logger.info(f"Refreshing metadata for video {video_id}")
+        metadata = await fetch_video_metadata(video_id)
+        
+        if not metadata:
+            logger.warning(f"Could not fetch metadata for video {video_id}")
+            return False
+        
+        # Update database
+        await db.execute(
+            update(Video)
+            .where(Video.id == video.id)
+            .values(
+                youtube_thumbnail_url=metadata.get("thumbnail_url"),
+                youtube_duration=metadata.get("duration_iso"),
+                youtube_channel_title=metadata.get("channel_title"),
+                youtube_metadata_updated_at=datetime.now()
+            )
+        )
+        await db.commit()
+        
+        logger.info(f"Successfully refreshed metadata for video {video_id}")
+        return True
+        
+    except Exception as e:
+        logger.error(f"Error refreshing metadata for video {video_id}: {e}")
+        await db.rollback()
+        return False
+
+
+async def refresh_stale_video_metadata(
+    db: AsyncSession,
+    days_threshold: int = 7,
+    batch_size: int = 50,
+    rate_limit_delay: float = 0.1
+) -> dict:
+    """
+    Refresh metadata for videos that haven't been updated in the specified number of days.
+    
+    Respects YouTube API rate limits by processing in batches with delays.
+    
+    Args:
+        db: Database session
+        days_threshold: Number of days since last update to consider stale (default: 7)
+        batch_size: Number of videos to process in each batch (default: 50)
+        rate_limit_delay: Delay in seconds between API calls (default: 0.1)
+        
+    Returns:
+        Dictionary with refresh statistics
+    """
+    try:
+        # Calculate cutoff date
+        cutoff_date = datetime.now() - timedelta(days=days_threshold)
+        
+        # Query videos that need refreshing
+        # Either never updated or updated more than threshold days ago
+        result = await db.execute(
+            select(Video).where(
+                and_(
+                    Video.youtube_video_id.isnot(None),
+                    (
+                        (Video.youtube_metadata_updated_at.is_(None)) |
+                        (Video.youtube_metadata_updated_at < cutoff_date)
+                    )
+                )
+            )
+        )
+        videos = result.scalars().all()
+        
+        total_videos = len(videos)
+        logger.info(f"Found {total_videos} videos to refresh metadata for")
+        
+        if total_videos == 0:
+            return {
+                "total": 0,
+                "successful": 0,
+                "failed": 0,
+                "skipped": 0
+            }
+        
+        successful = 0
+        failed = 0
+        
+        # Process in batches to respect rate limits
+        for i in range(0, total_videos, batch_size):
+            batch = videos[i:i + batch_size]
+            logger.info(f"Processing batch {i // batch_size + 1} ({len(batch)} videos)")
+            
+            for video in batch:
+                success = await refresh_video_metadata(db, video.youtube_video_id, video)
+                if success:
+                    successful += 1
+                else:
+                    failed += 1
+                
+                # Rate limiting delay
+                await asyncio.sleep(rate_limit_delay)
+            
+            # Longer delay between batches
+            if i + batch_size < total_videos:
+                await asyncio.sleep(1)
+        
+        logger.info(
+            f"Metadata refresh completed: {successful} successful, {failed} failed out of {total_videos} total"
+        )
+        
+        return {
+            "total": total_videos,
+            "successful": successful,
+            "failed": failed,
+            "skipped": 0
+        }
+        
+    except Exception as e:
+        logger.error(f"Error in refresh_stale_video_metadata: {e}")
+        return {
+            "total": 0,
+            "successful": 0,
+            "failed": 0,
+            "skipped": 0,
+            "error": str(e)
+        }
+
+

--- a/backend/app/services/youtube_metadata.py
+++ b/backend/app/services/youtube_metadata.py
@@ -1,0 +1,161 @@
+"""
+Service to fetch and parse YouTube video metadata from YouTube Data API v3.
+"""
+import asyncio
+import re
+from typing import Dict, Any, Optional
+from datetime import datetime
+
+from googleapiclient.discovery import build
+from googleapiclient.http import HttpRequest
+from googleapiclient.errors import HttpError
+
+from app.config import YOUTUBE_API_KEY
+from app.utils.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class CustomHttpRequest(HttpRequest):
+    """Custom HTTP client to add referer header for YouTube API."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.headers["referer"] = "http://localhost:8030"
+
+
+def build_youtube_client():
+    """Build YouTube API client with custom referer header."""
+    if not YOUTUBE_API_KEY:
+        raise ValueError("YOUTUBE_API_KEY is not configured")
+    return build("youtube", "v3", developerKey=YOUTUBE_API_KEY, requestBuilder=CustomHttpRequest)
+
+
+youtube = build_youtube_client() if YOUTUBE_API_KEY else None
+
+
+def parse_duration(iso_duration: str) -> Optional[str]:
+    """
+    Parse ISO 8601 duration string to seconds.
+    
+    Args:
+        iso_duration: ISO 8601 duration string (e.g., "PT5M30S" for 5 minutes 30 seconds)
+        
+    Returns:
+        Duration in seconds as string, or None if parsing fails
+    """
+    if not iso_duration:
+        return None
+    
+    try:
+        # ISO 8601 duration format: PT[nH][nM][nS]
+        # Examples: PT5M30S, PT1H2M3S, PT30S
+        pattern = r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?'
+        match = re.match(pattern, iso_duration)
+        
+        if not match:
+            logger.warning(f"Could not parse duration: {iso_duration}")
+            return None
+        
+        hours = int(match.group(1) or 0)
+        minutes = int(match.group(2) or 0)
+        seconds = int(match.group(3) or 0)
+        
+        total_seconds = hours * 3600 + minutes * 60 + seconds
+        return str(total_seconds)
+    except Exception as e:
+        logger.error(f"Error parsing duration {iso_duration}: {e}")
+        return None
+
+
+def get_best_thumbnail(thumbnails: Dict[str, Any]) -> Optional[str]:
+    """
+    Select the highest quality thumbnail from YouTube thumbnail options.
+    
+    Priority: maxres > standard > high > medium > default
+    
+    Args:
+        thumbnails: Dictionary of thumbnail options from YouTube API
+        
+    Returns:
+        URL of the best quality thumbnail, or None if not available
+    """
+    if not thumbnails:
+        return None
+    
+    # Priority order: maxres > standard > high > medium > default
+    quality_order = ['maxres', 'standard', 'high', 'medium', 'default']
+    
+    for quality in quality_order:
+        if quality in thumbnails and thumbnails[quality].get('url'):
+            return thumbnails[quality]['url']
+    
+    return None
+
+
+async def fetch_video_metadata(video_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Fetch video metadata from YouTube Data API v3.
+    
+    Args:
+        video_id: YouTube video ID
+        
+    Returns:
+        Dictionary containing video metadata or None if not found/error
+    """
+    # Build client if needed
+    try:
+        client = youtube if youtube else build_youtube_client()
+    except ValueError:
+        logger.error("YouTube API client not initialized (YOUTUBE_API_KEY missing)")
+        return None
+    
+    if not client:
+        logger.error("Could not build YouTube API client")
+        return None
+    
+    try:
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: client.videos().list(
+                part="snippet,contentDetails",
+                id=video_id
+            ).execute()
+        )
+        
+        if "items" not in response or len(response["items"]) == 0:
+            logger.warning(f"No video found for ID: {video_id}")
+            return None
+        
+        video_data = response["items"][0]
+        snippet = video_data.get("snippet", {})
+        content_details = video_data.get("contentDetails", {})
+        
+        # Extract metadata
+        duration_iso = content_details.get("duration", "")
+        duration_seconds = parse_duration(duration_iso) if duration_iso else None
+        
+        thumbnails = snippet.get("thumbnails", {})
+        thumbnail_url = get_best_thumbnail(thumbnails)
+        
+        metadata = {
+            "title": snippet.get("title", ""),
+            "description": snippet.get("description", ""),
+            "published_at": snippet.get("publishedAt"),
+            "thumbnail_url": thumbnail_url,
+            "duration": duration_seconds,
+            "duration_iso": duration_iso,
+            "channel_title": snippet.get("channelTitle", ""),
+            "channel_id": snippet.get("channelId", ""),
+        }
+        
+        logger.info(f"Successfully fetched metadata for video {video_id}")
+        return metadata
+        
+    except HttpError as e:
+        logger.error(f"YouTube API error fetching metadata for video {video_id}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error fetching metadata for video {video_id}: {e}")
+        return None
+

--- a/backend/app/utils/youtube_cookies.py
+++ b/backend/app/utils/youtube_cookies.py
@@ -4,10 +4,12 @@ import random
 import time
 import asyncio
 import re
+import json
 from datetime import datetime
 from typing import Optional, cast
 from http.cookiejar import MozillaCookieJar, Cookie
 from contextlib import contextmanager
+from collections import defaultdict
 
 from playwright_stealth import Stealth
 from playwright.async_api import async_playwright, BrowserContext, Page
@@ -326,8 +328,12 @@ async def _run_refresh(headless: bool, channel: Optional[str] = "chrome") -> boo
                 else:
                     logger.info("SUCCESS: All required authentication cookies extracted")
 
-                # Export cookies regardless (even incomplete cookies are better than none)
+                # Export cookies with diagnostic logging
                 await _export_cookies_to_netscape(cookies)
+                await _save_cookie_diagnostics(cookies)
+                
+                # Validate cookies are suitable for video downloads
+                await _validate_cookies_for_downloads(cookies)
 
                 await context.close()
                 _update_last_refresh_timestamp()
@@ -827,15 +833,20 @@ async def _validate_and_extract_cookies(context: BrowserContext) -> tuple[list[d
         tuple: (cookies_list, all_auth_cookies_found)
     """
     AUTH_COOKIE_NAMES = ['SID', 'HSID', 'SSID', 'APISID', 'SAPISID', 'LOGIN_INFO']
+    
+    # Video-download-specific cookies that help with video stream access
+    VIDEO_COOKIE_NAMES = ['VISITOR_INFO1_LIVE', 'PREF', 'YSC', 'CONSENT', '__Secure-3PSID', '__Secure-3PAPISID']
 
     all_cookies = await context.cookies()
 
-    # Filter to Google/YouTube domains
+    # Filter to Google/YouTube domains (including googlevideo.com for video downloads)
     relevant_domains = [
         ".youtube.com", "youtube.com", "www.youtube.com",
         ".google.com", "google.com", "www.google.com",
         "accounts.google.com", "myaccount.google.com",
-        "studio.youtube.com"
+        "studio.youtube.com",
+        "googlevideo.com", ".googlevideo.com",  # For video stream downloads
+        "music.youtube.com",
     ]
 
     cookies = [
@@ -850,11 +861,27 @@ async def _validate_and_extract_cookies(context: BrowserContext) -> tuple[list[d
         if name in AUTH_COOKIE_NAMES:
             found_auth[name] = cookie.get('domain')
 
+    # Check for video-specific cookies
+    found_video = {}
+    for cookie in cookies:
+        name = cookie.get('name')
+        if name in VIDEO_COOKIE_NAMES:
+            found_video[name] = cookie.get('domain')
+
     # Log results
-    logger.info(f"Total cookies: {len(cookies)}, Auth cookies: {len(found_auth)}/{len(AUTH_COOKIE_NAMES)}")
+    logger.info(f"Total cookies: {len(cookies)}, Auth cookies: {len(found_auth)}/{len(AUTH_COOKIE_NAMES)}, Video cookies: {len(found_video)}/{len(VIDEO_COOKIE_NAMES)}")
+    
+    logger.info("Authentication cookies:")
     for name in AUTH_COOKIE_NAMES:
         if name in found_auth:
             logger.info(f"  [OK] {name} (domain: {found_auth[name]})")
+        else:
+            logger.warning(f"  [MISSING] {name}")
+    
+    logger.info("Video-download cookies:")
+    for name in VIDEO_COOKIE_NAMES:
+        if name in found_video:
+            logger.info(f"  [OK] {name} (domain: {found_video[name]})")
         else:
             logger.warning(f"  [MISSING] {name}")
 
@@ -900,6 +927,168 @@ async def _export_cookies_to_netscape(cookies: list[dict]):
     except Exception:
         # os.chmod may not be supported on Windows in the same way; ignore
         pass
+
+async def _save_cookie_diagnostics(cookies: list[dict]):
+    """Save diagnostic information about extracted cookies to a JSON file."""
+    try:
+        _ensure_cookies_dir()
+        
+        # Group cookies by domain
+        cookies_by_domain = defaultdict(list)
+        cookies_by_type = defaultdict(list)
+        
+        AUTH_COOKIE_NAMES = ['SID', 'HSID', 'SSID', 'APISID', 'SAPISID', 'LOGIN_INFO']
+        VIDEO_COOKIE_NAMES = ['VISITOR_INFO1_LIVE', 'PREF', 'YSC', 'CONSENT', '__Secure-3PSID', '__Secure-3PAPISID']
+        
+        for cookie in cookies:
+            domain = cookie.get('domain', 'unknown')
+            name = cookie.get('name', 'unknown')
+            
+            cookies_by_domain[domain].append({
+                'name': name,
+                'path': cookie.get('path', '/'),
+                'secure': cookie.get('secure', False),
+                'expires': cookie.get('expires'),
+                'httpOnly': cookie.get('httpOnly', False),
+            })
+            
+            # Categorize by type
+            if name in AUTH_COOKIE_NAMES:
+                cookies_by_type['auth'].append(name)
+            elif name in VIDEO_COOKIE_NAMES:
+                cookies_by_type['video'].append(name)
+            elif name.startswith('__Secure-'):
+                cookies_by_type['secure'].append(name)
+            else:
+                cookies_by_type['other'].append(name)
+        
+        # Create diagnostic summary
+        diagnostic = {
+            'timestamp': datetime.now().isoformat(),
+            'total_cookies': len(cookies),
+            'domains': {
+                domain: {
+                    'count': len(cookie_list),
+                    'cookies': cookie_list
+                }
+                for domain, cookie_list in cookies_by_domain.items()
+            },
+            'cookie_types': {
+                'auth': {
+                    'count': len(cookies_by_type['auth']),
+                    'cookies': cookies_by_type['auth']
+                },
+                'video': {
+                    'count': len(cookies_by_type['video']),
+                    'cookies': cookies_by_type['video']
+                },
+                'secure': {
+                    'count': len(cookies_by_type['secure']),
+                    'cookies': cookies_by_type['secure']
+                },
+                'other': {
+                    'count': len(cookies_by_type['other']),
+                    'cookies': cookies_by_type['other'][:20]  # Limit to first 20
+                }
+            },
+            'domain_summary': {
+                domain: len(cookie_list)
+                for domain, cookie_list in cookies_by_domain.items()
+            }
+        }
+        
+        # Save to JSON file
+        diagnostic_file = os.path.join(BASE_COOKIES_DIR, 'cookies_diagnostics.json')
+        with open(diagnostic_file, 'w') as f:
+            json.dump(diagnostic, f, indent=2)
+        
+        # Log summary
+        logger.info(f"Cookie diagnostics saved to {diagnostic_file}")
+        logger.info(f"Cookies by domain: {dict(diagnostic['domain_summary'])}")
+        logger.info(f"Auth cookies: {len(cookies_by_type['auth'])}, Video cookies: {len(cookies_by_type['video'])}, Secure cookies: {len(cookies_by_type['secure'])}")
+        
+    except Exception as e:
+        logger.warning(f"Failed to save cookie diagnostics: {e}")
+
+async def _validate_cookies_for_downloads(cookies: list[dict]):
+    """Validate that extracted cookies are suitable for video downloads, not just metadata extraction.
+    
+    Checks:
+    - Cookie expiration times (warn if expiring soon)
+    - Presence of video-specific cookies
+    - Domain coverage for googlevideo.com access
+    """
+    try:
+        current_time = time.time()
+        expiring_soon = []
+        expired = []
+        
+        AUTH_COOKIE_NAMES = ['SID', 'HSID', 'SSID', 'APISID', 'SAPISID', 'LOGIN_INFO']
+        VIDEO_COOKIE_NAMES = ['VISITOR_INFO1_LIVE', 'PREF', 'YSC']
+        
+        # Check cookie expiration
+        for cookie in cookies:
+            name = cookie.get('name', '')
+            expires = cookie.get('expires')
+            
+            if expires and expires != -1:
+                expires_time = float(expires)
+                time_until_expiry = expires_time - current_time
+                
+                # Warn if cookie expires within 24 hours
+                if time_until_expiry < 0:
+                    expired.append(name)
+                elif time_until_expiry < 86400:  # 24 hours
+                    hours_until = time_until_expiry / 3600
+                    expiring_soon.append((name, hours_until))
+        
+        if expired:
+            logger.warning(f"Found {len(expired)} expired cookies: {expired[:5]}")
+        
+        if expiring_soon:
+            logger.warning(f"Found {len(expiring_soon)} cookies expiring within 24 hours:")
+            for name, hours in expiring_soon[:5]:
+                logger.warning(f"  - {name}: expires in {hours:.1f} hours")
+        
+        # Check for video-specific cookies
+        found_video_cookies = {name: False for name in VIDEO_COOKIE_NAMES}
+        for cookie in cookies:
+            name = cookie.get('name', '')
+            if name in VIDEO_COOKIE_NAMES:
+                found_video_cookies[name] = True
+        
+        missing_video = [name for name, found in found_video_cookies.items() if not found]
+        if missing_video:
+            logger.warning(f"Missing video-download cookies: {missing_video}")
+            logger.warning("These cookies help with video stream access but may not be critical if auth cookies are present")
+        else:
+            logger.info("All video-download cookies present")
+        
+        # Check domain coverage
+        domains = set(cookie.get('domain', '') for cookie in cookies)
+        has_google_domain = any('google.com' in d for d in domains)
+        has_youtube_domain = any('youtube.com' in d for d in domains)
+        
+        if not has_google_domain:
+            logger.warning("No cookies found for google.com domain - may cause issues")
+        if not has_youtube_domain:
+            logger.warning("No cookies found for youtube.com domain - may cause issues")
+        
+        # Note: googlevideo.com cookies are not always present, parent domain cookies should work
+        has_googlevideo = any('googlevideo.com' in d for d in domains)
+        if has_googlevideo:
+            logger.info("Found googlevideo.com cookies - good for direct video stream access")
+        else:
+            logger.info("No googlevideo.com cookies (parent domain cookies should work)")
+        
+        # Summary
+        if expired or (len(expiring_soon) > 3) or missing_video:
+            logger.warning("Cookie validation found potential issues - video downloads may fail")
+        else:
+            logger.info("Cookie validation passed - cookies appear suitable for video downloads")
+            
+    except Exception as e:
+        logger.warning(f"Cookie validation failed: {e}")
 
 def _update_last_refresh_timestamp():
     _ensure_cookies_dir()

--- a/backend/migrations/versions/f1a2b3c4d5e6_add_youtube_metadata_fields_to_videos.py
+++ b/backend/migrations/versions/f1a2b3c4d5e6_add_youtube_metadata_fields_to_videos.py
@@ -1,0 +1,38 @@
+"""Add YouTube metadata fields to videos table
+
+Revision ID: f1a2b3c4d5e6
+Revises: 920d05f5a88e
+Create Date: 2025-01-13 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = '920d05f5a88e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add YouTube metadata fields to videos table
+    op.add_column('videos', sa.Column('youtube_thumbnail_url', sa.String(length=500), nullable=True))
+    op.add_column('videos', sa.Column('youtube_duration', sa.String(length=50), nullable=True))
+    op.add_column('videos', sa.Column('youtube_channel_title', sa.String(length=255), nullable=True))
+    op.add_column('videos', sa.Column('youtube_metadata_updated_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove YouTube metadata fields from videos table
+    op.drop_column('videos', 'youtube_metadata_updated_at')
+    op.drop_column('videos', 'youtube_channel_title')
+    op.drop_column('videos', 'youtube_duration')
+    op.drop_column('videos', 'youtube_thumbnail_url')
+
+

--- a/frontend/app/(routes)/restaurants/[slug]/_components/restaurant-detail-client.tsx
+++ b/frontend/app/(routes)/restaurants/[slug]/_components/restaurant-detail-client.tsx
@@ -107,11 +107,11 @@ export default function RestaurantDetailClient({
       <Script id="breadcrumb-jsonld" type="application/ld+json">
         {JSON.stringify(
           buildBreadcrumbJsonLd([
-            { name: "Home", url: "https://www.nomtok.com" },
-            { name: "Restaurants", url: "https://www.nomtok.com/restaurants" },
+            { name: "Home", url: "https://nomtok.com" },
+            { name: "Restaurants", url: "https://nomtok.com/restaurants" },
             {
               name: toTitleFromSlug(String(hydratedRestaurant?.slug)),
-              url: `https://www.nomtok.com/restaurants/${String(hydratedRestaurant?.slug)}`,
+              url: `https://nomtok.com/restaurants/${String(hydratedRestaurant?.slug)}`,
             },
           ])
         )}

--- a/frontend/app/(routes)/restaurants/[slug]/page.tsx
+++ b/frontend/app/(routes)/restaurants/[slug]/page.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { buildPageMetadata } from "@/lib/seo/utils";
+import { canonicalForPath } from "@/lib/seo/site";
+import { buildVideoObjectJsonLd } from "@/lib/seo/video-jsonld";
+import { extractYouTubeVideoId, fetchYouTubeMetadata } from "@/lib/utils/youtube-metadata";
 import RestaurantDetailClient from "./_components/restaurant-detail-client";
 import RestaurantHero from "./_components/restaurant-hero";
 import axios from "axios";
@@ -158,11 +162,71 @@ export default async function RestaurantDetailPage({ params }: Props) {
     } catch {}
   }
 
+  // Generate VideoObject JSON-LD for embedded videos
+  const videoJsonLdScripts: JSX.Element[] = [];
+  
+  if (initialRestaurant?.listings) {
+    const restaurantUrl = canonicalForPath(`/restaurants/${slug}`);
+    const restaurantName = initialRestaurant.name || "";
+    
+    // Get unique videos from listings
+    const videoMap = new Map<string, { videoId: string; listing: Listing }>();
+    
+    for (const listing of initialRestaurant.listings) {
+      if (listing.approved && listing.video?.youtube_video_id) {
+        const videoId = listing.video.youtube_video_id;
+        if (!videoMap.has(videoId)) {
+          videoMap.set(videoId, { videoId, listing });
+        }
+      }
+    }
+    
+    // Fetch metadata and generate JSON-LD for each video
+    for (const { videoId, listing } of videoMap.values()) {
+      try {
+        const getVideoMetadataCached = unstable_cache(
+          async () => {
+            const base = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8030";
+            return await fetchYouTubeMetadata(videoId, base);
+          },
+          ["youtube-metadata", videoId],
+          { revalidate: 3600 } // Cache for 1 hour
+        );
+        
+        const metadata = await getVideoMetadataCached();
+        
+        if (metadata) {
+          const videoJsonLd = buildVideoObjectJsonLd({
+            videoId,
+            metadata,
+            restaurantUrl,
+            restaurantName,
+          });
+          
+          videoJsonLdScripts.push(
+            <Script
+              key={`video-jsonld-${videoId}`}
+              id={`video-jsonld-${videoId}`}
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{
+                __html: JSON.stringify(videoJsonLd),
+              }}
+            />
+          );
+        }
+      } catch (error) {
+        console.error(`Error generating VideoObject JSON-LD for video ${videoId}:`, error);
+        // Continue with other videos even if one fails
+      }
+    }
+  }
+
   return (
     <>
       {initialRestaurant && <div className="p-2">
         <RestaurantHero restaurant={initialRestaurant} />
       </div>}
+      {videoJsonLdScripts}
       <RestaurantDetailClient 
         slug={slug} 
         initialRestaurant={initialRestaurant} 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.nomtok.com"),
+  metadataBase: new URL("https://nomtok.com"),
   title: {
     default: "Nomtok",
     template: "%s | Nomtok",
@@ -30,13 +30,13 @@ export const metadata: Metadata = {
     "city guides",
   ],
   robots: { index: true, follow: true },
-  alternates: { canonical: "https://www.nomtok.com" },
+  alternates: { canonical: "https://nomtok.com" },
   openGraph: {
     type: "website",
     title: "Nomtok",
     description:
       "Discover amazing restaurants recommended by your favorite food influencers",
-    url: "https://www.nomtok.com",
+    url: "https://nomtok.com",
     images: [
       { url: "/hero-main.jpg", width: 1200, height: 630, alt: "Nomtok" },
     ],

--- a/frontend/lib/seo/site.ts
+++ b/frontend/lib/seo/site.ts
@@ -1,5 +1,5 @@
 export const siteConfig = {
-  baseUrl: "https://www.nomtok.com",
+  baseUrl: "https://nomtok.com",
   siteName: "Nomtok",
   defaultOgImage: "/hero-main.jpg",
   defaultKeywords: [

--- a/frontend/lib/seo/video-jsonld.ts
+++ b/frontend/lib/seo/video-jsonld.ts
@@ -1,0 +1,107 @@
+/**
+ * Utility to generate VideoObject JSON-LD schema for YouTube videos.
+ * 
+ * Follows Schema.org VideoObject specification:
+ * https://schema.org/VideoObject
+ */
+
+import { canonicalForPath } from "./site";
+
+export interface VideoMetadata {
+  title?: string;
+  description?: string;
+  published_at?: string;
+  thumbnail_url?: string;
+  duration?: string;
+  channel_title?: string;
+}
+
+export interface VideoObjectJsonLdOptions {
+  videoId: string;
+  metadata: VideoMetadata;
+  restaurantUrl: string;
+  restaurantName: string;
+}
+
+/**
+ * Build VideoObject JSON-LD schema for a YouTube video.
+ * 
+ * @param options - Video metadata and context
+ * @returns VideoObject JSON-LD object
+ */
+export function buildVideoObjectJsonLd({
+  videoId,
+  metadata,
+  restaurantUrl,
+  restaurantName,
+}: VideoObjectJsonLdOptions) {
+  const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+  const contentUrl = `https://www.youtube.com/watch?v=${videoId}`;
+  
+  // Ensure restaurant URL uses canonical non-www format
+  const canonicalRestaurantUrl = restaurantUrl.startsWith("https://www.nomtok.com")
+    ? restaurantUrl.replace("https://www.nomtok.com", "https://nomtok.com")
+    : restaurantUrl;
+  
+  const videoObject: any = {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    name: metadata.title || `${restaurantName} Review`,
+    description: metadata.description || `Review of ${restaurantName}`,
+    thumbnailUrl: metadata.thumbnail_url || undefined,
+    uploadDate: metadata.published_at || undefined,
+    embedUrl: embedUrl,
+    contentUrl: contentUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": canonicalRestaurantUrl,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Nomtok",
+      url: "https://nomtok.com",
+    },
+  };
+  
+  // Add duration if available (convert seconds to ISO 8601 if needed)
+  if (metadata.duration) {
+    // If duration is already in ISO 8601 format, use it
+    if (metadata.duration.startsWith("PT")) {
+      videoObject.duration = metadata.duration;
+    } else {
+      // Assume it's in seconds, convert to ISO 8601
+      const seconds = parseInt(metadata.duration, 10);
+      if (!isNaN(seconds)) {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = seconds % 60;
+        
+        let durationStr = "PT";
+        if (hours > 0) durationStr += `${hours}H`;
+        if (minutes > 0) durationStr += `${minutes}M`;
+        if (secs > 0) durationStr += `${secs}S`;
+        
+        videoObject.duration = durationStr;
+      }
+    }
+  }
+  
+  // Add creator if channel title is available
+  if (metadata.channel_title) {
+    videoObject.creator = {
+      "@type": "Person",
+      name: metadata.channel_title,
+    };
+  }
+  
+  // Remove undefined values
+  Object.keys(videoObject).forEach((key) => {
+    if (videoObject[key] === undefined) {
+      delete videoObject[key];
+    }
+  });
+  
+  return videoObject;
+}
+
+

--- a/frontend/lib/utils/youtube-metadata.ts
+++ b/frontend/lib/utils/youtube-metadata.ts
@@ -1,0 +1,62 @@
+/**
+ * Utility functions for YouTube video metadata extraction and fetching.
+ */
+
+/**
+ * Extract YouTube video ID from various URL formats or iframe src.
+ * 
+ * Supports:
+ * - https://www.youtube.com/watch?v=VIDEO_ID
+ * - https://youtu.be/VIDEO_ID
+ * - https://www.youtube.com/embed/VIDEO_ID
+ * - https://www.youtube.com/v/VIDEO_ID
+ * 
+ * @param url - YouTube URL or iframe src
+ * @returns Video ID or null if not found
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  if (!url) return null;
+  
+  const regex =
+    /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/;
+  const match = url.match(regex);
+  return match ? match[1] : null;
+}
+
+/**
+ * Fetch YouTube video metadata from backend API (server-side only).
+ * 
+ * @param videoId - YouTube video ID
+ * @param apiBaseUrl - Base URL for the API (defaults to NEXT_PUBLIC_API_URL)
+ * @returns Video metadata or null if not found
+ */
+export async function fetchYouTubeMetadata(
+  videoId: string,
+  apiBaseUrl?: string
+): Promise<{
+  title?: string;
+  description?: string;
+  published_at?: string;
+  thumbnail_url?: string;
+  duration?: string;
+  channel_title?: string;
+} | null> {
+  try {
+    const base = apiBaseUrl || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8030";
+    const response = await fetch(`${base}/youtube-metadata/${videoId}`);
+    
+    if (!response.ok) {
+      if (response.status === 404) {
+        return null;
+      }
+      throw new Error(`Failed to fetch metadata: ${response.statusText}`);
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.error(`Error fetching YouTube metadata for video ${videoId}:`, error);
+    return null;
+  }
+}
+
+


### PR DESCRIPTION
- Introduced new API endpoints for fetching and refreshing YouTube video metadata.
- Added fields for YouTube metadata (thumbnail URL, duration, channel title, last updated timestamp) to the Video model and database schema.
- Implemented a background service to refresh stale video metadata every week.
- Enhanced video download functionality to optionally disable Tor for downloads, addressing potential blocking by YouTube.
- Updated frontend components to support video metadata integration and JSON-LD generation for SEO optimization.